### PR TITLE
Require semi-valid email address. 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User
 
   validates :firstname, :presence => true
   validates :lastname, :presence => true
-  validates :email_address, :presence => true, :uniqueness => { case_sensitive: false }
+  validates :email_address, presence: true, uniqueness: { case_sensitive: false }, format: { with: /.+@.+\.{1}.{2,}/ }
   validates :height, :numericality => { integer_only: true, greater_than: 30, less_than: 96, allow_blank: true  }
   validates :weight, :numericality => { integer_only: true, greater_than: 60, less_than: 400, allow_blank: true }
   validates :handedness, :inclusion => { in: %w(left right both), message: "%{value} is not a valid option", allow_blank: true }

--- a/app/workers/mail_chimp_worker.rb
+++ b/app/workers/mail_chimp_worker.rb
@@ -21,7 +21,11 @@ class MailChimpWorker
       subscribe_body['status_if_new'] = 'unsubscribed'
     end
 
-    gibbon.lists(list_id).members(user.email_md5).upsert(body: subscribe_body)
+    begin
+      gibbon.lists(list_id).members(user.email_md5).upsert(body: subscribe_body)
+    rescue => exception
+      Bugsnag.notify(exception)
+    end
   end
 
   def list_id


### PR DESCRIPTION
Put error checking around the mailchimp subscription.