### PR TITLE
Remove unused registration statuses

### DIFF
--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -475,8 +475,8 @@ class LeaguesController < ApplicationController
             r = Registration.find(reg_id)
 
             if r
-                if r.status == 'cancelled'
-                    @errors << "Registration cancelled for #{r.user.name}."
+                if r.status == 'canceled'
+                    @errors << "Registration canceled for #{r.user.name}."
                 end
 
                 registrations << r

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -451,16 +451,16 @@ class LeaguesController < ApplicationController
 
     def preview_capture
         if params[:registration_group_id] && @rg = RegistrationGroup.find(params[:registration_group_id])
-            @authorized_registrants = {male: [], female: []}
+            @registrant_list = {male: [], female: []}
             @rg.members.each do |m|
                 if reg = @league.registration_for(m)
-                    @authorized_registrants[reg.gender.to_sym] << reg if reg.status == 'waitlisted'
+                    @registrant_list[reg.gender.to_sym] << reg if reg.status == 'waitlisted'
                 end
             end
         else
-            @authorized_registrants = {}
+            @registrant_list = {}
             %w(male female).each do |gender|
-                @authorized_registrants[gender.to_sym] = @league.registrations.waitlisted.where(gender: gender).sort('signup_timestamp' => 1)
+                @registrant_list[gender.to_sym] = @league.registrations.waitlisted.where(gender: gender).sort('signup_timestamp' => 1)
             end
         end
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,5 @@
 class RegistrationsController < ApplicationController
-    before_filter :load_registration_from_params, only: [:cancel, :edit, :update, :checkout, :approved, :cancelled, :show, :pay, :waitlist_check]
+    before_filter :load_registration_from_params, only: [:cancel, :edit, :update, :checkout, :approved, :canceled, :show, :pay, :waitlist_check]
     filter_access_to [:edit, :update, :show, :checkout, :cancel, :pay, :waitlist_check], attribute_check: true
 
     def create
@@ -32,7 +32,7 @@ class RegistrationsController < ApplicationController
         unless @registration.status == 'accepted'
             message = "You can only pay for your registration if it has been accepted into the league. Your current status is: '#{@registration.status}'."
             message = "You are already in that league, you don't need to pay again!" if @registration.status == 'active'
-            message = "You have cancelled your registration. Please contact help@afdc.com if you want to un-cancel." if @registration.status == 'canceled'
+            message = "You have canceled your registration. Please contact help@afdc.com if you want to un-cancel." if @registration.status == 'canceled'
             message = "You haven't been accepted into the league yet, so we can't accept your payment at this time." if @registration.status == 'pending'
             redirect_to registration_path(@registration), flash: {error: message} and return 
         end
@@ -69,7 +69,7 @@ class RegistrationsController < ApplicationController
     def cancel
         if @registration.cancel
             log_audit('Cancel', league: @registration.league, registration: @registration)
-            redirect_to registrations_user_path(@registration.user), notice: "Your registration has been cancelled." and return
+            redirect_to registrations_user_path(@registration.user), notice: "Your registration has been canceled." and return
         end
 
         redirect_to registrations_user_path(@registration.user), flash: {error: "Cancelling your registration failed, please contact a league commissioner."}

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -11,13 +11,13 @@ class NotificationMailer < ActionMailer::Base
     end
   end
 
-  def games_cancelled(notification_method_id, fieldsite_id, day_timestamp) 
+  def games_canceled(notification_method_id, fieldsite_id, day_timestamp) 
     notification_method = NotificationMethod.find(notification_method_id)
 
     @user      = notification_method.user
     @fieldsite = FieldSite.find(fieldsite_id)
     @game_day  = Time.at(day_timestamp)
 
-    mail(to: notification_method.target, subject: "AFDC Games Cancelled for #{@game_day.strftime('%B %d, %Y')}")
+    mail(to: notification_method.target, subject: "AFDC Games Canceled for #{@game_day.strftime('%B %d, %Y')}")
   end
 end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -34,7 +34,7 @@ class RegistrationMailer < ActionMailer::Base
     mail(to: @registration.user.email_address, subject: '[AFDC] Please pay for your ' + @league.name + ' registration before it expires!')
   end
 
-  def unpaid_registration_cancelled(registration_id)
+  def unpaid_registration_canceled(registration_id)
     @registration = Registration.find(registration_id)
     @user = @registration.user
     @league = @registration.league

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -40,7 +40,6 @@ class Registration
     after_save  :bust_league_cache
 
     scope :active, where(status: 'active')
-    scope :authorized, where(status: 'authorized')
     scope :accepted, where(status: 'accepted')
     scope :pending, where(status: 'pending')
     scope :canceled, where(status: 'canceled')

--- a/app/views/help/registration.html.haml
+++ b/app/views/help/registration.html.haml
@@ -21,11 +21,6 @@
         This functionality is temporarily disabled, but
         %a{:href => "mailto:help@afdc.com"} someone
         will be happy to make those changes for you.
-      %dt I'm listed as "inactive", what does that mean?
-      %dd
-        %p This means that your payment has not yet been processed and you are not yet guaranteed a spot in the league
-        %p Players who have authorized a payment will be moved to the active list on a first-come, first-served basis (unless otherwise noted by the commissioner) until the league is full.
-        %p Once the league is full, new players will be pulled in to replace cancellations and achieve league balance.
       %dt Oops! I can't play any more and I'd like a refund!
       %dd
         Please contact

--- a/app/views/leagues/manage_roster.html.haml
+++ b/app/views/leagues/manage_roster.html.haml
@@ -11,7 +11,7 @@
                 %span Active Registrants:
                 =@league.registrations.where(status: 'active').count
             %li
-                %span{class: 'hasTooltip', title: 'includes cancelled and waitlisted'} Total Registrants:
+                %span{class: 'hasTooltip', title: 'includes canceled and waitlisted'} Total Registrants:
                 =@league.registrations.count
             %li
                 %span{class: 'hasTooltip', title: 'active registrants without teams'} Orphans:

--- a/app/views/leagues/preview_capture.html.haml
+++ b/app/views/leagues/preview_capture.html.haml
@@ -62,7 +62,7 @@
           - if @rg
             %p
               You are activating players from a #{@league.core_options.type}. On the right, 
-              you will find all authorized players from that group, up to the gender limits for the league.
+              you will find all waitlisted players from that group, up to the gender limits for the league.
           - else
             %p
               If there are more registered players than available spots, spots will be filled based on registration time.
@@ -89,9 +89,9 @@
                 .well No spots remaining.
               - else
                 %ul
-                  - if @authorized_registrants[gender.to_sym].count <= 0
+                  - if @registrant_list[gender.to_sym].count <= 0
                     .alert.alert-info No #{gender} registrations to capture.
-                  - @authorized_registrants[gender.to_sym].each do |reg|
+                  - @registrant_list[gender.to_sym].each do |reg|
                     - break unless spots > 0
                     %li
                       =link_to reg.user.name, reg.user

--- a/app/views/leagues/registrations.html.haml
+++ b/app/views/leagues/registrations.html.haml
@@ -63,9 +63,7 @@
       <% if (registration_group) { %>
         <li><strong style="text-transform: capitalize"><%=window.core_type%>:</strong> <a href="#" class="show-group-details" data-group-id="<%=registration_group%>"><%= registration_group.substr(0,8) %></a></li>
       <% } %>
-      <% if (timestamps['authorized']) { %>
-        <li><strong>Paid:</strong> <%=moment.unix(timestamps['authorized']).format('MMM Do, h:mm a')%></li>
-      <% } else if (timestamps['pending']) { %>
+      <% } if (timestamps['pending']) { %>
         <li><strong>Reg:</strong> <%=moment.unix(timestamps['pending']).format('MMM Do, h:mm a')%></li>
       <% } %>
     </ul>
@@ -146,7 +144,6 @@
         %option{value: 'active'} Active
         %option{value: 'accepted'} Accepted
         %option{value: 'waitlisted'} Waitlisted
-        %option{value: 'authorized'} Authorized       
         %option{value: 'canceled'} Canceled
         %option{value: '', selected: true} All Statuses
       %select.span3{id: 'items-per-page'}

--- a/app/views/notification_mailer/games_cancelled.html.haml
+++ b/app/views/notification_mailer/games_cancelled.html.haml
@@ -1,6 +1,6 @@
 %p #{@user.firstname},
 
 %p 
-    Your games for #{@game_day.strftime('%A, %B %d, %Y')} at #{@fieldsite.name} have been cancelled.
+    Your games for #{@game_day.strftime('%A, %B %d, %Y')} at #{@fieldsite.name} have been canceled.
 
 %p To manage your notifications, you can visit #{link_to('your profile', user_notification_methods_url(@user))}.

--- a/app/views/registration_groups/index.html.haml
+++ b/app/views/registration_groups/index.html.haml
@@ -108,7 +108,7 @@
                   - else
                     - label_type = 'important'
                     - label_type = 'success' if reg.status == 'active'
-                    - label_type = 'info' if reg.status == 'authorized'
+                    - label_type = 'info' if reg.status == 'accepted'
                     - label_type = 'inverse' if reg.status == 'canceled'
                     %td
                       %span{class: "label label-#{label_type}"}=reg.status

--- a/app/views/users/registrations.html.haml
+++ b/app/views/users/registrations.html.haml
@@ -27,7 +27,7 @@
                         - if reg.status == 'accepted'
                             =link_to pay_registration_path(reg) do
                                 %i.icon.icon-shopping-cart
-                        - if false && reg.status == 'cancelled'
+                        - if false && reg.status == 'canceled'
                             = link_to cancel_registration_path(reg) do
                                 %i.icon-remove-circle
 - else

--- a/app/workers/game_cancellation_worker.rb
+++ b/app/workers/game_cancellation_worker.rb
@@ -52,7 +52,7 @@ class GameCancellationWorker
     end
 
     game_date     = Time.at(start_ts).strftime('%a, %b %e')
-    text_message  = "Bad news! Your AFDC games at #{@fieldsite.name} are cancelled for today (#{game_date})."
+    text_message  = "Bad news! Your AFDC games at #{@fieldsite.name} are canceled for today (#{game_date})."
 
     player_list.each do |user_id, p|
         notify_user(p, text_message, start_ts)
@@ -73,7 +73,7 @@ class GameCancellationWorker
         end
 
         if nm.method == 'email'
-            NotificationMailer.games_cancelled(nm._id, @fieldsite._id, game_day_timestamp).deliver
+            NotificationMailer.games_canceled(nm._id, @fieldsite._id, game_day_timestamp).deliver
         end
     end
   end

--- a/app/workers/registration_cancellation_worker.rb
+++ b/app/workers/registration_cancellation_worker.rb
@@ -52,7 +52,7 @@ class RegistrationCancellationWorker
           league: reg.league,
           registration: reg
         )
-        RegistrationMailer.unpaid_registration_cancelled(reg.id.to_s).deliver
+        RegistrationMailer.unpaid_registration_canceled(reg.id.to_s).deliver
     end    
   end
 

--- a/lib/tasks/league.rake
+++ b/lib/tasks/league.rake
@@ -27,7 +27,7 @@ namespace :league do
                     r.acceptance_expires_at = nil
                     r.warning_email_sent_at = nil
                     if r.save
-                        RegistrationMailer.unpaid_registration_cancelled(r.id.to_s).deliver
+                        RegistrationMailer.unpaid_registration_canceled(r.id.to_s).deliver
                     end
                     next
                 end


### PR DESCRIPTION
 - `Authorized` is a hold-over from a previous registration flow and has been replaced with `pending`.
 - `Cancelled` is really just an inconsistent spelling of the actual status: `canceled` 