### PR TITLE
Shorten Registration Window

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,11 +74,11 @@ $(function(){
 
     $(".countdown").each(function(i, el){
         if (this.getAttribute("data-expiration")) {
+            var expiredMessage = this.getAttribute("data-expire-message");
             var expirationDate = el.getAttribute("data-expiration");
             var updateExpiration = function() {
                 var cd = countdown(expirationDate * 1000);
 
-                console.log(cd);
                 var msg = cd.toString();
 
                 if (cd.minutes < 3) {
@@ -86,7 +86,7 @@ $(function(){
                 }
 
                 if (cd.value >= 0) {
-                    msg = "<b>REGISTRATION EXPIRED</b>";
+                    msg = "<b>" + expiredMessage + "</b>";
                     clearInterval(myInverval);
                 }
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -71,6 +71,33 @@ $(function(){
             e.preventDefault();
         }
     });
+
+    $(".countdown").each(function(i, el){
+        if (this.getAttribute("data-expiration")) {
+            var expirationDate = el.getAttribute("data-expiration");
+            var updateExpiration = function() {
+                var cd = countdown(expirationDate * 1000);
+
+                console.log(cd);
+                var msg = cd.toString();
+
+                if (cd.minutes < 3) {
+                    msg = "<b>" + msg + "</b>";
+                }
+
+                if (cd.value >= 0) {
+                    msg = "<b>REGISTRATION EXPIRED</b>";
+                    clearInterval(myInverval);
+                }
+
+                el.innerHTML = msg;
+            };
+
+            updateExpiration();
+
+            var myInverval = setInterval(updateExpiration, 1000);
+        }
+    });
 });
 
 

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -29,6 +29,18 @@ class LeaguesController < ApplicationController
     end
 
     def update
+        # Changing the number of available slots while players are registering or on the waitlist is... not supported yet
+        if @league.registrations.registering.count > 0 ||
+            @league.registrations.registering_waitlisted.count > 0 ||
+            @league.registrations.waitlisted.count > 0
+            
+            if league_params[:male_limit] != @league.male_limit || 
+                league_params[:female_limit] != @league.female_limit
+                @league.errors.add(:male_limit, "Changing player limits while players are registering is not permitted.")
+                render :edit and return
+            end
+        end
+
         if @league.update_attributes(league_params)
             redirect_to @league, notice: "League Updated Successfully"
         else

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -5,6 +5,11 @@ class PaymentsController < ApplicationController
         redirect_to registrations_user_path(current_user), flash: {error: "Registration not found."} and return 
     end
 
+    if registration.is_expired?
+      redirect_to register_league_path(registration.league), flash: {error: "You took too long to register. Please try again."}
+      return
+    end
+
     price    = registration.price
 
     result = Braintree::Transaction.sale(

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -102,7 +102,7 @@ class RegistrationsController < ApplicationController
         # There's room for this player; accept and move them to the payment phase
         @registration.status = 'registering'
         @registration.warning_email_sent_at = nil
-        @registration.acceptance_expires_at = league.current_expiration_times[gender.to_sym]
+        @registration.expires_at = league.current_expiration_times[gender.to_sym]
         @registration.save!
         redirect_to pay_registration_path(@registration)
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,31 +1,9 @@
 class RegistrationsController < ApplicationController
-    before_filter :load_registration_from_params, only: [:cancel, :edit, :update, :checkout, :approved, :canceled, :show, :pay, :waitlist_check]
-    filter_access_to [:edit, :update, :show, :checkout, :cancel, :pay, :waitlist_check], attribute_check: true
+    before_filter :load_registration_from_params, only: [:cancel, :edit, :update, :checkout, :approved, :canceled, :show, :pay]
+    filter_access_to [:edit, :update, :show, :checkout, :cancel, :pay], attribute_check: true
 
     def create
-        league = League.find(params[:registration][:league_id])
-
-        if league.registration_for(current_user)
-            redirect_to registrations_user_path(current_user), flash: {error: "You have already registered for this league."}
-            return
-        end
-
-        unless league.registration_open_for?(current_user)
-            redirect_to league_path(league), flash: {error: "The registrations for this league have either closed or haven't opened yet. Try again later!"}
-            return
-        end
-
-        @registration = Registration.new
-        populate_registration
-
-        if @registration.save
-            log_audit('Register', league: league, registration: @registration)
-            MailChimpWorker.perform_async(@registration.user._id.to_s, params[:subscribe])
-            redirect_to waitlist_check_registration_path(@registration)
-            return
-        end
-
-        render :edit
+        raise "This should not be possible."
     end
 
     def pay
@@ -35,6 +13,11 @@ class RegistrationsController < ApplicationController
             message = "You have canceled your registration. Please contact help@afdc.com if you want to un-cancel." if @registration.status == 'canceled'
             message = "It's not your turn to register yet, so we can't accept your payment at this time." if @registration.status == 'queued'
             redirect_to registration_path(@registration), flash: {error: message} and return 
+        end
+
+        if @registration.is_expired?
+            redirect_to register_league_path(@registration.league), flash: {error: "You took too long to register. Please try again."}
+            return
         end
 
         # This player doesn't have to pay
@@ -50,9 +33,47 @@ class RegistrationsController < ApplicationController
     end
 
     def update
+        status_types = Hash.new(:invalid)
+
+        # Pending and Queued registrations shouldn't be able to be changed
+        # Canceled and Expired registrations should get put back in the Queued state in leagues_controller#register
+
+        status_types["registering"] = :new
+        status_types["active"]      = :edit
+        
+        status_types["registering_waitlisted"] = :new
+        status_types["waitlist"]             = :edit
+
+        reg_status_type = status_types[@registration.status]
+
+        if reg_status_type == :invalid
+            redirect_to league_path(@registration.league), flash: {error: "'#{@registration.status}' is not a valid registration status."}
+            return
+        end
+
+        if reg_status_type == :new
+            unless @registration.league.registration_open_for?(current_user)
+                redirect_to league_path(@registration.league), flash: {error: "The registrations for this league have either closed or haven't opened yet. Try again later!"}
+                return
+            end
+
+            if @registration.is_expired?
+                redirect_to register_league_path(@registration.league), flash: {error: "You took too long to register. Please try again."}
+                return
+            end
+
+            @registration.signup_timestamp = Time.now
+            @registration.paid = false
+        end
+
         populate_registration
 
-        if @registration.save
+        if @registration.save == false
+            render :edit
+            return
+        end
+
+        if reg_status_type == :edit
             redirect_destination = registrations_user_path(current_user)
             redirect_destination = registrations_league_path(@registration.league) if @registration.user != current_user
 
@@ -60,7 +81,18 @@ class RegistrationsController < ApplicationController
             return
         end
 
-        render :edit
+        log_audit('Register', league: @registration.league, registration: @registration)
+        MailChimpWorker.perform_async(@registration.user._id.to_s, params[:subscribe])
+
+        if @registration.status == "registering_waitlisted"
+            @registration.update(status: "waitlist")
+            RegistrationMailer.delay.registration_waitlisted(@registration._id.to_s)
+            redirect_to league_path(@registration.league), notice: "You have been added to the waitlist."
+            return
+        end
+
+        # If we get here, the user has successfully registered and now just needs to pay
+        redirect_to pay_registration_path(@registration)
     end
 
     def show
@@ -75,50 +107,12 @@ class RegistrationsController < ApplicationController
         redirect_to registrations_user_path(@registration.user), flash: {error: "Cancelling your registration failed, please contact a league commissioner."}
     end
 
-    def waitlist_check
-        if @registration.status != 'pending'
-            redirect_to registration_path(@registration), notice: "Your registration status is '#{@registration.status}'."
-            return
-        end
-
-        # Collect Registration Information
-        league          = @registration.league
-        gender          = @registration.gender
-        all_registered  = league.registrations.where(gender: gender)
-        spots_available = league.gender_limit(gender)
-        active          = all_registered.active
-        registering     = all_registered.registering
-        earlier_pending = all_registered.pending.where(:_id.lt => @registration._id)
-
-        # Flag Waitlisted Registrations
-        if (all_registered.waitlisted.count > 0) || (registering.count + active.count + earlier_pending.count >= spots_available)
-            @registration.status = 'waitlisted'
-            @registration.save
-            RegistrationMailer.delay.registration_waitlisted(@registration._id.to_s)
-            redirect_to registration_path(@registration), notice: "The league is currently full, but we added you to the waitlist. We'll let you know if spots open up!"
-            return
-        end
-
-        # There's room for this player; accept and move them to the payment phase
-        @registration.status = 'registering'
-        @registration.warning_email_sent_at = nil
-        @registration.expires_at = league.current_expiration_times[gender.to_sym]
-        @registration.save!
-        redirect_to pay_registration_path(@registration)
-    end
-
     private
 
     def populate_registration
         reg_params = params[:registration]
 
-        if @registration.new_record?
-            @registration.league = League.find(reg_params[:league_id])
-            @registration.signup_timestamp = Time.now
-            @registration.user = current_user
-            @registration.status = 'pending'
-            @registration.paid = false
-        end
+        @registration.memoize_user_info
 
         if reg_params[:waiver_accepted] == '1'
             @registration.waiver_acceptance_date = Time.now
@@ -133,7 +127,6 @@ class RegistrationsController < ApplicationController
             'general' => reg_params[:gen_availability],
             'attend_tourney_eos' => (reg_params[:eos_availability] == '1')
         }
-        @registration.gender = @registration.user.gender
         @registration.player_strength = reg_params[:player_strength]
         @registration.self_rank = reg_params[:self_rank]
         @registration.notes = reg_params[:notes]
@@ -141,15 +134,6 @@ class RegistrationsController < ApplicationController
         if reg_params[:pair_id]
             @registration.pair_id = reg_params[:pair_id].first
         end
-        @registration.user_data = {
-            birthdate: @registration.user.birthdate,
-            firstname: @registration.user.firstname,
-            middlename: @registration.user.middlename,
-            lastname: @registration.user.lastname,
-            gender: @registration.user.gender,
-            height: @registration.user.height,
-            weight: @registration.user.weight
-        }
 
         if permitted_to? :manage, @registration.league
             @registration.commish_rank = reg_params[:commish_rank]

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -182,17 +182,7 @@ class League
   end
 
   def current_expiration_times
-    expirations = { male: nil, female: nil }
-
-    unless male_limit.nil?
-        expirations[:male]   = (registrations.male.count >= male_limit)? 48.hours.from_now : nil
-    end
-
-    unless female_limit.nil?
-        expirations[:female] = (registrations.female.count >= female_limit)? 48.hours.from_now : nil
-    end
-
-    return expirations
+    { male: 10.minutes.from_now, female: 10.minutes.from_now }
   end
 
   def invite!(player)

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -181,8 +181,12 @@ class League
     end
   end
 
+  def current_expiration_time
+    10.minutes.from_now
+  end
+
   def current_expiration_times
-    { male: 10.minutes.from_now, female: 10.minutes.from_now }
+    { male: current_expiration_time, female: current_expiration_time }
   end
 
   def invite!(player)

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -45,6 +45,7 @@ class Registration
     scope :pending, where(status: 'pending')
     scope :canceled, where(status: 'canceled')
     scope :waitlisted, where(status: 'waitlisted')
+    scope :queued, where(status: 'queued')
 
     scope :male, where(gender: 'male')
     scope :female, where(gender: 'female')

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -41,7 +41,7 @@ class Registration
     after_save  :bust_league_cache
 
     scope :active, where(status: 'active')
-    scope :accepted, where(status: 'accepted')
+    scope :registering, where(status: 'registering')
     scope :pending, where(status: 'pending')
     scope :canceled, where(status: 'canceled')
     scope :waitlisted, where(status: 'waitlisted')
@@ -79,7 +79,7 @@ class Registration
     end
 
     def accept(expires_at = nil)
-        self.status                = 'accepted'
+        self.status                = 'registering'
         self.warning_email_sent_at = nil
         self.acceptance_expires_at = expires_at
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -45,7 +45,8 @@ class Registration
     scope :pending, where(status: 'pending')
     scope :canceled, where(status: 'canceled')
     scope :waitlisted, where(status: 'waitlisted')
-    scope :queued, where(status: 'queued')
+    scope :queued, where(status: 'queued', :expires_at.gt => Time.now)
+    scope :expired, where(status: 'expired').or(status: 'queued', :expires_at.lte => Time.now)
 
     scope :male, where(gender: 'male')
     scope :female, where(gender: 'female')

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -15,7 +15,8 @@ class Registration
     field :g_rank, type: Float
     field :shirt_size
     
-    field :acceptance_expires_at, type: DateTime
+    field :acceptance_expires_at, type: DateTime # DEPRECATED
+    field :expires_at, type: DateTime
     field :warning_email_sent_at, type: DateTime  
 
     field :waiver_acceptance_date, type: DateTime
@@ -46,7 +47,7 @@ class Registration
     scope :canceled, where(status: 'canceled')
     scope :waitlisted, where(status: 'waitlisted')
     scope :queued, where(status: 'queued', :expires_at.gt => Time.now)
-    scope :expired, where(status: 'expired').or(status: 'queued', :expires_at.lte => Time.now)
+    scope :expired, where(status: 'expired').or(status: 'registering', :expires_at.lte => Time.now)
 
     scope :male, where(gender: 'male')
     scope :female, where(gender: 'female')
@@ -82,7 +83,7 @@ class Registration
     def accept(expires_at = nil)
         self.status                = 'registering'
         self.warning_email_sent_at = nil
-        self.acceptance_expires_at = expires_at
+        self.expires_at = expires_at
 
         if self.save
             RegistrationMailer.delay.registration_accepted(self._id.to_s)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,10 @@ class User
     Team.where({ '$or' => [{'captains' => id}, {'reporters' => id}]})
   end
 
+  def gender_noun
+    {"male" => "man", "female" => "woman"}[gender]
+  end
+
   def braintree_customer_id
     cid = id.to_s
     begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,6 +188,6 @@ class User
   end
 
   def registrations_with_payment_due
-    registrations.accepted.select {|reg| reg.league.started? == false}
+    registrations.registering.select {|reg| reg.league.started? == false}
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -88,7 +88,7 @@
             %p The following registrations need to be finished and paid for soon!
             %ul
               -regs_due.each do |reg|
-                %li #{link_to(reg.league.name, register_league_path(reg.league))} ($#{number_with_precision(reg.price, precision: 2)}) Expires in: <span class="countdown" data-expiration="#{reg.expires_at.to_i}">#{distance_of_time_in_words_to_now(reg.expires_at)}</span>
+                %li #{link_to(reg.league.name, register_league_path(reg.league))} ($#{number_with_precision(reg.price, precision: 2)}) Expires in: <span class="countdown" data-expiration="#{reg.expires_at.to_i}" data-expire-message="Registration Expired.">#{distance_of_time_in_words_to_now(reg.expires_at)}</span>
       = yield
       - if Rails.env.development?
         %div{style: 'margin-top: 50px'}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,8 @@
     = javascript_include_tag '/javascripts/jquery-2.1.0.min.js'
     = javascript_include_tag '/bootstrap/js/bootstrap.min.js'
     = javascript_include_tag "application"
+    = javascript_include_tag('//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js')
+    = javascript_include_tag('///cdnjs.cloudflare.com/ajax/libs/countdown/2.6.0/countdown.min.js')
 
     = yield :page_scripts
 
@@ -79,13 +81,14 @@
       - if flash[:error]
         .alert.alert-error= flash[:error]
       - if current_user
-        - regs_due = current_user.registrations_with_payment_due
+        - regs_due = current_user.registrations.registering
         - if regs_due.count > 0
           .alert.alert-success
-            %h4 Please pay the following registration fees to join the league:
+            %h4 Time is ticking!
+            %p The following registrations need to be finished and paid for soon!
             %ul
-              -current_user.registrations_with_payment_due.each do |reg|
-                %li #{link_to(reg.league.name, pay_registration_path(reg))} ($#{number_with_precision(reg.price, precision: 2)})
+              -regs_due.each do |reg|
+                %li #{link_to(reg.league.name, register_league_path(reg.league))} ($#{number_with_precision(reg.price, precision: 2)}) Expires in: <span class="countdown" data-expiration="#{reg.expires_at.to_i}">#{distance_of_time_in_words_to_now(reg.expires_at)}</span>
       = yield
       - if Rails.env.development?
         %div{style: 'margin-top: 50px'}

--- a/app/views/layouts/new_homepage.html.haml
+++ b/app/views/layouts/new_homepage.html.haml
@@ -11,6 +11,7 @@
     = stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css'
     = javascript_include_tag '/javascripts/jquery-2.1.0.min.js'
     = javascript_include_tag '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js'
+    = javascript_include_tag "application"
     = javascript_include_tag('//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js')
     = javascript_include_tag('///cdnjs.cloudflare.com/ajax/libs/countdown/2.6.0/countdown.min.js')
 
@@ -85,7 +86,7 @@
             %p The following registrations need to be finished and paid for soon!
             %ul
               -regs_due.each do |reg|
-                %li #{link_to(reg.league.name, register_league_path(reg.league))} ($#{number_with_precision(reg.price, precision: 2)}) Expires in: <span class="countdown" data-expiration="#{reg.expires_at.to_i}">#{distance_of_time_in_words_to_now(reg.expires_at)}</span>
+                %li #{link_to(reg.league.name, register_league_path(reg.league))} ($#{number_with_precision(reg.price, precision: 2)}) Expires in: <span class="countdown" data-expiration="#{reg.expires_at.to_i}" data-expire-message="Registration Expired.">#{distance_of_time_in_words_to_now(reg.expires_at)}</span>
       = yield
       - if Rails.env.development?
         %div{style: 'margin-top: 50px'}

--- a/app/views/layouts/new_homepage.html.haml
+++ b/app/views/layouts/new_homepage.html.haml
@@ -11,6 +11,9 @@
     = stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css'
     = javascript_include_tag '/javascripts/jquery-2.1.0.min.js'
     = javascript_include_tag '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js'
+    = javascript_include_tag('//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js')
+    = javascript_include_tag('///cdnjs.cloudflare.com/ajax/libs/countdown/2.6.0/countdown.min.js')
+
 
     = yield :page_scripts
     = yield :page_styles
@@ -75,13 +78,14 @@
       - if flash[:error]
         .alert.alert-error= flash[:error]
       - if current_user
-        - regs_due = current_user.registrations_with_payment_due
+        - regs_due = current_user.registrations.registering
         - if regs_due.count > 0
           .alert.alert-success
-            %h4 Please pay the following registration fees to join the league:
+            %h4 Time is ticking!
+            %p The following registrations need to be finished and paid for soon!
             %ul
-              -current_user.registrations_with_payment_due.each do |reg|
-                %li #{link_to(reg.league.name, pay_registration_path(reg))} ($#{number_with_precision(reg.price, precision: 2)})
+              -regs_due.each do |reg|
+                %li #{link_to(reg.league.name, register_league_path(reg.league))} ($#{number_with_precision(reg.price, precision: 2)}) Expires in: <span class="countdown" data-expiration="#{reg.expires_at.to_i}">#{distance_of_time_in_words_to_now(reg.expires_at)}</span>
       = yield
       - if Rails.env.development?
         %div{style: 'margin-top: 50px'}

--- a/app/views/leagues/_form.html.haml
+++ b/app/views/leagues/_form.html.haml
@@ -40,11 +40,13 @@
             .control-group{ class: ('error' if errors[:male_limit].any? || errors[:female_limit].any?)}
                 %label.control-label Gender Limit
                 .controls
+                    - registering_players = @league.registrations.registering.count + @league.registrations.registering_waitlisted.count + @league.registrations.waitlisted.count
                     M:
-                    =f.text_field :male_limit, class: 'span1'
+                    =f.text_field :male_limit, class: 'span1', disabled: (registering_players > 0)
                     F:
-                    =f.text_field :female_limit, class: 'span1'
-
+                    =f.text_field :female_limit, class: 'span1', disabled: (registering_players > 0)
+                    - if registering_players > 0
+                        %span.help-block Limits may not be changed while players are registering.
                     - if errors[:male_limit].any?
                         %span.help-block=errors[:male_limit].first
                     - if errors[:female_limit].any?

--- a/app/views/leagues/preview_capture.html.haml
+++ b/app/views/leagues/preview_capture.html.haml
@@ -27,10 +27,10 @@
           %td= stats[:waitlisted_female] = @league.registrations.female.waitlisted.count
           %td= stats[:waitlisted_male] + stats[:waitlisted_female]
         %tr
-          %th Accepted (Not Paid)
-          %td= stats[:accepted_male] = @league.registrations.male.accepted.count
-          %td= stats[:accepted_female] = @league.registrations.female.accepted.count
-          %td= stats[:accepted_male] + stats[:accepted_female]
+          %th Registering (Not Paid)
+          %td= stats[:registering_male] = @league.registrations.male.registering.count
+          %td= stats[:registering_female] = @league.registrations.female.registering.count
+          %td= stats[:registering_male] + stats[:registering_female]
         %tr
           %td
             %strong Active (Paid)
@@ -47,8 +47,8 @@
         %tr.success
           %td
             %strong Spots Remaining
-          %td= stats[:spots_male] = stats[:limit_male] - (stats[:active_male] + stats[:accepted_male])
-          %td= stats[:spots_female] = stats[:limit_female] - (stats[:active_female] + stats[:accepted_female])
+          %td= stats[:spots_male] = stats[:limit_male] - (stats[:active_male] + stats[:registering_male])
+          %td= stats[:spots_female] = stats[:limit_female] - (stats[:active_female] + stats[:registering_female])
           %td= stats[:spots_female] + stats[:spots_male]
     %hr
     %h4 Activate Players
@@ -58,7 +58,7 @@
           %p
             This page allows you to accept players up to the cap established for the league.
           %p
-            On the right, you will see a list of all players who will be accepted if you click the button below.
+            On the right, you will see a list of all players who will be allowed to register if you click the button below.
           - if @rg
             %p
               You are activating players from a #{@league.core_options.type}. On the right, 

--- a/app/views/leagues/registration_queue.html.haml
+++ b/app/views/leagues/registration_queue.html.haml
@@ -1,0 +1,38 @@
+- content_for :title, @league.name
+= render :partial => '/pageheader', :locals => {subtitle: 'League Registration', breadcrumbs: {'Leagues' => leagues_path, @league.name => league_path(@league), 'Registration' => nil}}
+
+.well
+    %h4 #{@league.name} Registration Queue
+
+    %p
+        The league isn't quite full yet, but it could fill up soon. Players will have a chance to register on a
+        first-come, first-served basis. Here's the current league registration stats:
+
+    %dl
+        %dt Total Spots for #{current_user.gender_noun.pluralize}
+        %dd #{@total_spots}
+
+        %dt Registered
+        %dd #{@regs_active}
+
+        %dt Registering Now
+        %dd #{@regs_registering}
+
+        %dt Queued Ahead of You
+        %dd #{@regs_queued_earlier}
+
+        %dt Next Update In:
+        %dd
+            <span class="countdown" data-expiration="#{60.seconds.from_now.to_i}" data-expire-message="Refresh page now">60 seconds</span>
+    
+    %h5 
+        Please stay on this page to retain your spot in line. If you leave, 
+        you may be pushed to the end of the line.
+
+- content_for :page_scripts do
+    :javascript
+        $(function(){
+            setTimeout(function() {
+                location.reload(true);
+            }, 59*1000);
+        });

--- a/app/views/leagues/registrations.html.haml
+++ b/app/views/leagues/registrations.html.haml
@@ -142,8 +142,9 @@
         %option{value: '', selected: true} Men & Women
       %select.span3{id: 'status'}
         %option{value: 'active'} Active
-        %option{value: 'accepted'} Accepted
+        %option{value: 'registering'} Registering
         %option{value: 'waitlisted'} Waitlisted
+        %option{value: 'expired'} Expired
         %option{value: 'canceled'} Canceled
         %option{value: '', selected: true} All Statuses
       %select.span3{id: 'items-per-page'}

--- a/app/views/leagues/registrations.html.haml
+++ b/app/views/leagues/registrations.html.haml
@@ -82,7 +82,6 @@
 - content_for :page_scripts do
   = javascript_include_tag('//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.5.2/underscore-min.js')
   = javascript_include_tag('//code.jquery.com/ui/1.10.4/jquery-ui.js')
-  = javascript_include_tag('//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js')
   = javascript_include_tag('/javascripts/registrant_browser.js')
   = javascript_include_tag('/javascripts/jquery-scrollto.js')
   = javascript_include_tag('/javascripts/jquery.sparkline.min.js')

--- a/app/views/leagues/show.html.haml
+++ b/app/views/leagues/show.html.haml
@@ -31,8 +31,8 @@
                         =active = Registration.where(league: @league, status: 'active', gender: gender).count
                         ="/#{limit}" if limit
                     .span2
-                        %strong Accepted: 
-                        =accepted = Registration.where(league: @league, status: 'accepted', gender: gender).count
+                        %strong Registering: 
+                        =registering = Registration.where(league: @league, status: 'registering', gender: gender).count
                     .span2
                         %strong Total Registered:
                         -waitlisted =  Registration.where(league: @league, status: 'waitlisted', gender: gender).count
@@ -41,11 +41,11 @@
                     .span7
                         - if limit
                             - active_pct = [(active.to_f / limit.to_f), 0].max * 100
-                            - accepted_pct = [(accepted.to_f / limit.to_f), 0].max * 100
+                            - registering_pct = [(registering.to_f / limit.to_f), 0].max * 100
                             - waitlist_pct = [(waitlisted.to_f / limit.to_f), 0].max * 100
                             .progress.progress-striped.active
                                 .bar.bar-success{style: "width: #{number_to_percentage(active_pct)}"}
-                                .bar.bar-info{style: "width: #{number_to_percentage(accepted_pct)}"}
+                                .bar.bar-info{style: "width: #{number_to_percentage(registering_pct)}"}
                                 .bar.bar-warning{style: "width: #{number_to_percentage(waitlist_pct)}"}
             %hr
 

--- a/app/views/registration_groups/index.html.haml
+++ b/app/views/registration_groups/index.html.haml
@@ -108,7 +108,7 @@
                   - else
                     - label_type = 'important'
                     - label_type = 'success' if reg.status == 'active'
-                    - label_type = 'info' if reg.status == 'accepted'
+                    - label_type = 'info' if reg.status == 'registering'
                     - label_type = 'inverse' if reg.status == 'canceled'
                     %td
                       %span{class: "label label-#{label_type}"}=reg.status

--- a/app/views/registration_mailer/registration_accepted.html.haml
+++ b/app/views/registration_mailer/registration_accepted.html.haml
@@ -1,7 +1,7 @@
 %p #{@user.firstname},
 
 %p
-  Your registration has been accepted for #{link_to(@league.name, league_url(@league))}, but you are not yet active in the league.
+  You are invited to register for #{link_to(@league.name, league_url(@league))}, but you are not yet active in the league.
   In order to join the league, you must pay your registration fee. 
 
 - if @registration.acceptance_expires_at

--- a/app/views/registrations/_form.html.haml
+++ b/app/views/registrations/_form.html.haml
@@ -1,4 +1,4 @@
--if (@registration.status != 'active') && (@registration.league.comped? (@registration.new_record? ? current_user : @registration.user))
+-if (@registration.status != 'active') && (@registration.league.comped? (@registration.user))
     .alert.alert-info This registration will be comped by the league
 
 = bootstrap_form_for(@registration, html: { class: 'form-horizontal' }, help: :block) do |f|
@@ -24,7 +24,7 @@
                     = check_box_tag :subscribe, 1, checked: true
                     Send Me AFDC Updates
 
-    - if @registration.new_record?
+    - if @registration.status == 'registering' || @registration.status == 'registering_waitlisted'
         .control-group
             .controls
                 = f.check_box :waiver_accepted, value: 1, label: raw('I have read, understand, and accept the <br /> AFDC\'s <a href="http://blog.afdc.com/wp-content/uploads/2012/05/2012-AFDC-Waiver-Minors.pdf">liability waiver</a> and <a href="http://www.afdc.com/refund-policy/">refund policy</a>.')

--- a/app/views/registrations/edit.html.haml
+++ b/app/views/registrations/edit.html.haml
@@ -37,6 +37,11 @@
                                 %button{type: "submit", class: 'btn btn-primary'} Do it!
 
     .span7
+        - if @registration.status == "registering_waitlisted"
+            .alert.alert-block
+                %h4 Waitlist Registration
+                This league is full. By submitting your registration you will be added to the waitlist
+                and notified if a spot opens up for you. 
         %h4= @registration.user.name
         %dl.dl-horizontal
             %dt Gender:

--- a/app/views/registrations/show.html.haml
+++ b/app/views/registrations/show.html.haml
@@ -11,7 +11,7 @@
                             You're in!
                         %p
                             You've registered and paid. There's nothing left to do! Enjoy #{@registration.league.name}!
-                    - when 'accepted'
+                    - when 'registering'
                         %h2
                             = fa_icon 'warning-sign'
                             You're Almost Done...

--- a/app/views/registrations/show.html.haml
+++ b/app/views/registrations/show.html.haml
@@ -18,12 +18,12 @@
                         %p
                             We haven't received your payment for this league!
                             #{link_to("Click here to pay now!", pay_registration_path(@registration))}
-                        - if @registration.acceptance_expires_at
+                        - if @registration.expires_at
                             %p
                                 %em Note:
                                 Your registration will expire in approximately
                                 %strong
-                                    #{distance_of_time_in_words Time.now, @registration.acceptance_expires_at}. 
+                                    #{distance_of_time_in_words Time.now, @registration.expires_at}. 
                                 After that, you'll be put on the wait list and may not get a chance to play.
                     - when 'waitlisted'
                         %h2

--- a/app/views/users/registrations.html.haml
+++ b/app/views/users/registrations.html.haml
@@ -24,7 +24,7 @@
                     %td= reg.signup_timestamp.to_formatted_s(:long)
                     %td
                         = reg.status
-                        - if reg.status == 'accepted'
+                        - if reg.status == 'registering'
                             =link_to pay_registration_path(reg) do
                                 %i.icon.icon-shopping-cart
                         - if false && reg.status == 'canceled'

--- a/app/workers/registration_cancellation_worker.rb
+++ b/app/workers/registration_cancellation_worker.rb
@@ -7,44 +7,21 @@ class RegistrationCancellationWorker
     open_leagues.each do |league|
       expirations   = league.current_expiration_times
 
-      # Set Expirations
-      league.registrations.registering.where(acceptance_expires_at: nil).each do |reg|
-        gender = reg.gender.to_sym
-        next if expirations[gender].nil?
-
-        add_expiration(reg, expirations[gender])
-      end
-
       # Process expirations
-      league.registrations.registering.where(:acceptance_expires_at.lte => Time.now).each do |reg|
+      league.registrations.expired.where(:status.ne => "expired").each do |reg|
         expire_registration(reg)
       end
 
       # Process warning emails
       league.registrations.registering.where(:acceptance_expires_at.lte => 24.hours.from_now, warning_email_sent_at: nil).each do |reg|
-        send_warning(reg)
+        # send_warning(reg)
       end
     end    
   end
 
-  def add_expiration(reg, expiration)
-    reg.acceptance_expires_at = expiration
-    reg.warning_email_sent_at = nil
-    if reg.save
-        AuditLog.create(
-          action: 'AddExpiration',
-          league: reg.league,
-          registration: reg,
-          details: {new_expiration: expiration}
-        )
-        RegistrationMailer.stale_accepted_registration(reg.id.to_s).deliver
-    end
-  end
-
   def expire_registration(reg)
-    reg.status                = 'waitlisted'
-    reg.signup_timestamp      = Time.now
-    reg.acceptance_expires_at = nil
+    reg.status                = 'expired'
+    reg.expires_at            = nil
     reg.warning_email_sent_at = nil
     if reg.save
         AuditLog.create(

--- a/app/workers/registration_cancellation_worker.rb
+++ b/app/workers/registration_cancellation_worker.rb
@@ -8,7 +8,7 @@ class RegistrationCancellationWorker
       expirations   = league.current_expiration_times
 
       # Set Expirations
-      league.registrations.accepted.where(acceptance_expires_at: nil).each do |reg|
+      league.registrations.registering.where(acceptance_expires_at: nil).each do |reg|
         gender = reg.gender.to_sym
         next if expirations[gender].nil?
 
@@ -16,12 +16,12 @@ class RegistrationCancellationWorker
       end
 
       # Process expirations
-      league.registrations.accepted.where(:acceptance_expires_at.lte => Time.now).each do |reg|
+      league.registrations.registering.where(:acceptance_expires_at.lte => Time.now).each do |reg|
         expire_registration(reg)
       end
 
       # Process warning emails
-      league.registrations.accepted.where(:acceptance_expires_at.lte => 24.hours.from_now, warning_email_sent_at: nil).each do |reg|
+      league.registrations.registering.where(:acceptance_expires_at.lte => 24.hours.from_now, warning_email_sent_at: nil).each do |reg|
         send_warning(reg)
       end
     end    

--- a/app/workers/registration_payment_reminder_worker.rb
+++ b/app/workers/registration_payment_reminder_worker.rb
@@ -7,7 +7,7 @@ class RegistrationPaymentReminderWorker
 
     return unless r.present?
 
-    if r.status == 'accepted'
+    if r.status == 'registering'
         logger.info { "#{registration_id} Not yet paid. :(" }
         RegistrationMailer.stale_accepted_registration(registration_id).deliver
     end

--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -28,7 +28,7 @@ authorization do
 		has_permission_on :registration_groups, to: [:index]
 		has_permission_on :registrations, to: [:create]
 		has_permission_on :payments, to: [:create]
-		has_permission_on :leagues, to: [:register, :registrations, :invite_pair, :leave_pair, :missing_spirit_reports]
+		has_permission_on :leagues, to: [:register, :registrations, :invite_pair, :leave_pair, :missing_spirit_reports, :registration_queue]
 		has_permission_on :profile, to: [:index, :edit_g_rank, :update_g_rank]
 		has_permission_on :spirit_reports, to: [:index, :new, :create, :show, :edit, :update]
 

--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -45,7 +45,7 @@ authorization do
 			if_attribute sender_id: is { user._id }
 		end
 
-		has_permission_on :registrations, to: [:checkout, :show, :pay, :edit, :update, :cancel, :waitlist_check] do
+		has_permission_on :registrations, to: [:checkout, :show, :pay, :edit, :update, :cancel] do
 			if_attribute user_id: is { user._id }
 		end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Platinum::Application.routes.draw do
     member do
       get 'register'
       get 'registrations'
+      get 'registration_queue'
       post 'registrations'
 
       get 'preview_capture'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,6 @@ Platinum::Application.routes.draw do
     member do
       put 'cancel'
       get 'pay'
-      get 'waitlist_check'
     end
   end
 

--- a/lib/tasks/league.rake
+++ b/lib/tasks/league.rake
@@ -1,11 +1,11 @@
 namespace :league do
-    desc 'Expire old, accepted registrations and send warning emails'
+    desc 'Expire old registrations and send warning emails'
     task expire_registrations: :environment do
         League.not_started.each do |l|
             print "#{l.name} (#{l.id})\n"
             expirations = l.current_expiration_times
 
-            l.registrations.accepted.each do |r|
+            l.registrations.registering.each do |r|
                 gender = r.gender.to_sym
 
                 if expirations[gender] && r.acceptance_expires_at.nil?

--- a/lib/tasks/league.rake
+++ b/lib/tasks/league.rake
@@ -1,6 +1,7 @@
 namespace :league do
     desc 'Expire old registrations and send warning emails'
     task expire_registrations: :environment do
+        raise "This rake task is deprecated"
         League.not_started.each do |l|
             print "#{l.name} (#{l.id})\n"
             expirations = l.current_expiration_times

--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -1,0 +1,41 @@
+namespace :paperclip do
+  desc "migrage to DigitalOcean Spaces"
+  task :migrate => :environment do
+    AWS.config(
+      access_key_id: ENV['S3_ACCESS_KEY_ID'],
+      secret_access_key: ENV['S3_SECRET_ACCESS_KEY']
+    )
+
+    s3 = AWS::S3.new
+    bucket = s3.buckets[ENV['S3_PAPERCLIP_BUCKET']]
+
+    classes = [%w(Team avatar), %w(User avatar)]
+
+    classes.each do |class_info|
+      klass    = class_info[0].capitalize.constantize
+      att_type = class_info[1].downcase
+
+      puts "Migrating #{klass}:#{att_type}..."
+      styles = klass.first.send(att_type).styles.map{|style| style[0]}
+
+      klass.each do |instance|
+        puts "\t#{instance.id} (#{instance.avatar.exists?})"
+        next if instance.send(att_type).exists? == false
+        next if instance.send(att_type).url.include?('digitaloceanspaces')
+
+        styles.each do |style|
+          puts "\t\t#{style}"
+          extension = instance.send(att_type).path(style.to_sym).split(".").last
+          file_path = instance.send(att_type).path(style.to_sym)
+          new_path  = "#{klass.downcase.pluralize}/#{att_type.pluralize}/#{style}/#{instance.id}.#{extension}"
+          file = File.open(file_path)
+
+          attachment = bucket.objects[new_path].write(file, acl: :public_read)
+          break
+        end
+        break
+      end
+      break
+    end
+  end
+end


### PR DESCRIPTION
Players no longer have 48 hours to register. Instead, their spot is reserved the moment they hit the registration page and they have 10 minutes to complete their registration. Live timers follow players through the site to let them know when they are about out of time.