### PR TITLE
Create default scope for pronouns

### DIFF
--- a/app/models/pronoun.rb
+++ b/app/models/pronoun.rb
@@ -1,6 +1,8 @@
 class Pronoun
-	include Mongoid::Document
+  include Mongoid::Document
   field :label, type: String
   field :display, type: String
   field :default, type: Boolean
+
+  scope :defaults, where(default: true)
 end


### PR DESCRIPTION
Only some pronouns should be displayed in the dropdown by default.